### PR TITLE
Handle callback queries in conversations

### DIFF
--- a/src/Zanzara/Context.php
+++ b/src/Zanzara/Context.php
@@ -61,8 +61,13 @@ class Context
     private $cache;
 
     /**
-     * @param  Update  $update
-     * @param  ContainerInterface  $container
+     * @var ConversationManager
+     */
+    private $conversationManager;
+
+    /**
+     * @param Update $update
+     * @param ContainerInterface $container
      */
     public function __construct(Update $update, ContainerInterface $container)
     {
@@ -70,10 +75,11 @@ class Context
         $this->container = $container;
         $this->browser = $container->get(Browser::class);
         $this->cache = $container->get(ZanzaraCache::class);
+        $this->conversationManager = $container->get(ConversationManager::class);
     }
 
     /**
-     * @param  string  $key
+     * @param string $key
      * @param $value
      */
     public function set(string $key, $value): void
@@ -82,7 +88,7 @@ class Context
     }
 
     /**
-     * @param  string  $key
+     * @param string $key
      * @return mixed|null
      */
     public function get(string $key)
@@ -117,15 +123,16 @@ class Context
      *
      * This callable must be take on parameter of type Context
      * @param $handler
+     * @param bool $skipListeners
      * @return PromiseInterface
      * @throws \DI\DependencyException
      * @throws \DI\NotFoundException
      */
-    public function nextStep($handler): PromiseInterface
+    public function nextStep($handler, bool $skipListeners = false): PromiseInterface
     {
         // update is not null when used within the Context
         $chatId = $this->update->/** @scrutinizer ignore-call */ getEffectiveChat()->getId();
-        return $this->cache->setConversationHandler($chatId, $this->getCallable($handler));
+        return $this->conversationManager->setConversationHandler($chatId, $this->getCallable($handler), $skipListeners);
     }
 
     /**
@@ -140,7 +147,7 @@ class Context
     {
         // update is not null when used within the Context
         $chatId = $this->update->/** @scrutinizer ignore-call */ getEffectiveChat()->getId();
-        return $this->cache->deleteConversationCache($chatId);
+        return $this->conversationManager->deleteConversationCache($chatId);
     }
 
     /**

--- a/src/Zanzara/ConversationManager.php
+++ b/src/Zanzara/ConversationManager.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zanzara;
+
+use Closure;
+use Opis\Closure\SerializableClosure;
+use React\Promise\PromiseInterface;
+
+/**
+ *
+ */
+class ConversationManager
+{
+
+    private const CONVERSATION = "CONVERSATION";
+
+    /**
+     * @var ZanzaraCache
+     */
+    private $cache;
+
+    public function __construct(ZanzaraCache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get key of the conversation by chatId
+     * @param $chatId
+     * @return string
+     */
+    private function getConversationKey($chatId): string
+    {
+        return self::CONVERSATION . strval($chatId);
+    }
+
+    public function setConversationHandler($chatId, $handler, bool $skipListeners): PromiseInterface
+    {
+        $key = "state";
+        $cacheKey = $this->getConversationKey($chatId);
+        if ($handler instanceof Closure) {
+            $handler = new SerializableClosure($handler);
+        }
+        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners]);
+    }
+
+    public function getConversationHandler($chatId): PromiseInterface
+    {
+        return $this->cache->get($this->getConversationKey($chatId))
+            ->then(function ($conversation) {
+                if (empty($conversation["state"])) {
+                    return null;
+                }
+
+                $handler = $conversation["state"][0];
+                $handler = unserialize($handler);
+                if ($handler instanceof SerializableClosure) {
+                    $handler = $handler->getClosure();
+                }
+                return [$handler, $conversation["state"][1]];
+            });
+    }
+
+    /**
+     * delete a cache iteam and return the promise
+     * @param $chatId
+     * @return PromiseInterface
+     */
+    public function deleteConversationCache($chatId): PromiseInterface
+    {
+        return $this->cache->deleteCache([$this->getConversationKey($chatId)]);
+    }
+
+}

--- a/src/Zanzara/Listener/ListenerResolver.php
+++ b/src/Zanzara/Listener/ListenerResolver.php
@@ -51,21 +51,15 @@ abstract class ListenerResolver extends ListenerCollector
             case CallbackQuery::class:
                 $callbackQuery = $update->getCallbackQuery();
                 $text = $callbackQuery->getMessage() ? $callbackQuery->getMessage()->getText() : null;
-                $textListener = $dataListener = null;
                 if ($text) {
-                    $textListener = $this->findAndPush($listeners, 'cb_query_texts', $text);
+                    $this->findAndPush($listeners, 'cb_query_texts', $text);
                 }
                 if ($callbackQuery->getData()) {
-                    $dataListener = $this->findAndPush($listeners, 'cb_query_data', $callbackQuery->getData());
+                    $this->findAndPush($listeners, 'cb_query_data', $callbackQuery->getData());
                 }
-
                 $chatId = $update->getEffectiveChat() ? $update->getEffectiveChat()->getId() : null;
                 if ($chatId) {
-                    if (!$textListener && !$dataListener) {
-                        $this->cache->callHandlerByChatId($chatId, $update, $this->container);
-                        break;
-                    }
-                    $this->cache->deleteConversationCache($chatId);
+                    $this->cache->callHandlerByChatId($chatId, $update, $this->container);
                 }
                 break;
         }

--- a/src/Zanzara/Zanzara.php
+++ b/src/Zanzara/Zanzara.php
@@ -41,6 +41,11 @@ class Zanzara extends ListenerResolver
     private $loop;
 
     /**
+     * @var ZanzaraCache
+     */
+    private $cache;
+
+    /**
      * @param string $botToken
      * @param Config|null $config
      */
@@ -73,6 +78,7 @@ class Zanzara extends ListenerResolver
             $this->container->set(\React\Filesystem\Filesystem::class, \React\Filesystem\Filesystem::create($this->loop));
         }
         $this->cache = $this->container->get(ZanzaraCache::class);
+        $this->conversationManager = $this->container->get(ConversationManager::class);
         $this->container->set(Zanzara::class, $this);
     }
 

--- a/tests/zen-circus/conversation/cb_query_conversation.php
+++ b/tests/zen-circus/conversation/cb_query_conversation.php
@@ -1,0 +1,23 @@
+<?php
+
+use Zanzara\Context;
+use Zanzara\Zanzara;
+
+require __DIR__ . '/../../bootstrap.php';
+
+$bot = new Zanzara($_ENV['BOT_TOKEN']);
+
+$bot->onCommand('start', function (Context $ctx) {
+    $ctx->sendMessage('How are you?', ['reply_markup' => ['inline_keyboard' => [
+        [['callback_data' => 'fine', 'text' => 'Fine'], ['callback_data' => 'bad', 'text' => 'Bad']]
+    ]]]);
+    $ctx->nextStep("step");
+});
+
+function step(Context $ctx)
+{
+    $data = $ctx->getCallbackQuery()->getData();
+    $ctx->sendMessage("You replied with $data");
+}
+
+$bot->run();

--- a/tests/zen-circus/conversation/skip_listeners_conversation.php
+++ b/tests/zen-circus/conversation/skip_listeners_conversation.php
@@ -1,0 +1,25 @@
+<?php
+
+use Zanzara\Context;
+use Zanzara\Zanzara;
+
+require __DIR__ . '/../../bootstrap.php';
+
+$bot = new Zanzara($_ENV['BOT_TOKEN']);
+
+$bot->onCommand('start', function (Context $ctx) {
+    $ctx->sendMessage('How are you?');
+//    $ctx->nextStep("step"); // should enter in "escape" command listener
+    $ctx->nextStep("step", true); // should enter in conversation step
+});
+
+$bot->onCommand('escape', function (Context $ctx) {
+    $ctx->sendMessage('Escape command triggered');
+});
+
+function step(Context $ctx)
+{
+    $ctx->sendMessage("Ok");
+}
+
+$bot->run();


### PR DESCRIPTION
This, should partially fix the issue #22, BUT it's also true that if the cbquery match some listener, the conversation is discarded. As I written in the issue, if for example we want force the user to follow conversation/step by step wizard it can simply escape by typing any other command.
@cheeghi Feel free to edit this branch if you have a better solution 😄 