### PR TITLE
Fallback fixes

### DIFF
--- a/src/Zanzara/Context.php
+++ b/src/Zanzara/Context.php
@@ -488,4 +488,11 @@ class Context
         return $this->container->get(LoopInterface::class);
     }
 
+    /**
+     * @return bool
+     */
+    public function isCallbackQuery(): bool
+    {
+        return $this->getCallbackQuery() !== null;
+    }
 }

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -57,11 +57,6 @@ abstract class ListenerCollector
     protected $listeners = [];
 
     /**
-     * @var Listener
-     */
-    protected $fallbackListener;
-
-    /**
      * @var ContainerInterface
      */
     protected $container;
@@ -437,7 +432,7 @@ abstract class ListenerCollector
     public function fallback($callback): MiddlewareCollector
     {
         $listener = new Listener($callback, $this->container);
-        $this->fallbackListener = $listener;
+        $this->listeners['fallback'] = $listener;
         return $listener;
     }
 

--- a/src/Zanzara/Listener/ListenerResolver.php
+++ b/src/Zanzara/Listener/ListenerResolver.php
@@ -40,10 +40,10 @@ abstract class ListenerResolver extends ListenerCollector
                 $callbackQuery = $update->getCallbackQuery();
                 $text = $callbackQuery->getMessage() ? $callbackQuery->getMessage()->getText() : null;
                 if ($text) {
-                    $this->findListenerAndPush($listeners, 'cb_query_texts', $text);
+                    $this->findListenerAndPush($listeners, 'cb_query_texts', $text, true);
                 }
                 if ($callbackQuery->getData()) {
-                    $this->findListenerAndPush($listeners, 'cb_query_data', $callbackQuery->getData());
+                    $this->findListenerAndPush($listeners, 'cb_query_data', $callbackQuery->getData(), true);
                 }
                 $chatId = $update->getEffectiveChat() ? $update->getEffectiveChat()->getId() : null;
                 if ($chatId) {
@@ -80,7 +80,7 @@ abstract class ListenerResolver extends ListenerCollector
                         $skipListeners = $handlerInfo[1];
 
                         if (!$skipListeners && $text) {
-                            $listener = $this->findListenerAndPush($listeners, 'messages', $text);
+                            $listener = $this->findListenerAndPush($listeners, 'messages', $text, true);
                             if (!$listener) {
                                 $listeners[] = new Listener($handlerInfo[0], $this->container);
                             } else {
@@ -108,9 +108,10 @@ abstract class ListenerResolver extends ListenerCollector
      * @param Listener[] $listeners
      * @param string $listenerType
      * @param string $listenerId
+     * @param bool $skipFallback
      * @return Listener|null
      */
-    private function findListenerAndPush(array &$listeners, string $listenerType, string $listenerId): ?Listener
+    private function findListenerAndPush(array &$listeners, string $listenerType, string $listenerId, bool $skipFallback = false): ?Listener
     {
         $typedListeners = $this->listeners[$listenerType] ?? [];
         foreach ($typedListeners as $regex => $listener) {
@@ -120,7 +121,7 @@ abstract class ListenerResolver extends ListenerCollector
             }
         }
 
-        if ($this->fallbackListener !== null) {
+        if ($this->fallbackListener !== null && !$skipFallback) {
             $listeners[] = $this->fallbackListener;
             return $this->fallbackListener;
         }

--- a/src/Zanzara/Listener/ListenerResolver.php
+++ b/src/Zanzara/Listener/ListenerResolver.php
@@ -37,29 +37,26 @@ abstract class ListenerResolver extends ListenerCollector
         switch ($updateType) {
 
             case CallbackQuery::class:
+                $chatId = $update->getEffectiveChat() ? $update->getEffectiveChat()->getId() : null;
                 $callbackQuery = $update->getCallbackQuery();
                 $text = $callbackQuery->getMessage() ? $callbackQuery->getMessage()->getText() : null;
-                if ($text) {
-                    $this->findListenerAndPush($listeners, 'cb_query_texts', $text, true);
-                }
-                if ($callbackQuery->getData()) {
-                    $this->findListenerAndPush($listeners, 'cb_query_data', $callbackQuery->getData(), true);
-                }
-                $chatId = $update->getEffectiveChat() ? $update->getEffectiveChat()->getId() : null;
-                if ($chatId) {
-                    $this->conversationManager->getConversationHandler($chatId)
-                        ->then(function ($handlerInfo) use ($deferred, &$listeners) {
-                            if ($handlerInfo) {
-                                $listeners[] = new Listener($handlerInfo[0], $this->container);
+                $this->conversationManager->getConversationHandler($chatId)
+                    ->then(function ($handlerInfo) use ($deferred, $callbackQuery, $text, &$listeners) {
+                        if (!$handlerInfo) { // if we are not in a conversation, call the listeners as usual
+                            if ($text) {
+                                $this->findListenerAndPush($listeners, 'cb_query_texts', $text);
                             }
-                            $deferred->resolve($listeners);
-                        })->otherwise(function ($e) use ($deferred) {
-                            // if something goes wrong, reject the promise
-                            $deferred->reject($e);
-                        });
-                } else {
-                    $deferred->resolve($listeners);
-                }
+                            if ($callbackQuery->getData()) {
+                                $this->findListenerAndPush($listeners, 'cb_query_data', $callbackQuery->getData());
+                            }
+                        } else { // if we are in a conversation, redirect it only to the conversation step
+                            $listeners[] = new Listener($handlerInfo[0], $this->container);
+                        }
+                        $deferred->resolve($listeners);
+                    })->otherwise(function ($e) use ($deferred) {
+                        // if something goes wrong, reject the promise
+                        $deferred->reject($e);
+                    });
                 break;
 
             case Message::class:
@@ -67,25 +64,24 @@ abstract class ListenerResolver extends ListenerCollector
                 $chatId = $update->getEffectiveChat()->getId();
                 $this->conversationManager->getConversationHandler($chatId)
                     ->then(function ($handlerInfo) use ($chatId, $text, $deferred, &$listeners) {
-                        if (!$handlerInfo) {
+                        if (!$handlerInfo) { // if we are not in a conversation, call the listeners as usual
                             $this->findListenerAndPush($listeners, 'messages', $text);
-                            $deferred->resolve($listeners);
-                            return;
-                        }
-
-                        $skipListeners = $handlerInfo[1];
-
-                        if (!$skipListeners && $text) {
+                        } elseif (!$handlerInfo[1] && $text) {
+                            // if we are in a conversation, and listeners are not skipped by the step call,
+                            // try to call the matching listeners
                             $listener = $this->findListenerAndPush($listeners, 'messages', $text, true);
                             if (!$listener) {
+                                // if no listeners are found, call the next conversation step
                                 $listeners[] = new Listener($handlerInfo[0], $this->container);
                             } else {
+                                // if listener is found, escape the conversation
                                 $this->conversationManager->deleteConversationCache($chatId);
                             }
                         } else {
+                            // if the coversation is forcing only the conversation handlers,
+                            // skip the other listeners
                             $listeners[] = new Listener($handlerInfo[0], $this->container);
                         }
-
                         $deferred->resolve($listeners);
                     })->otherwise(function ($e) use ($deferred) {
                         // if something goes wrong, reject the promise

--- a/tests/Listener/CallbackQueryTest.php
+++ b/tests/Listener/CallbackQueryTest.php
@@ -99,28 +99,9 @@ class CallbackQueryTest extends TestCase
             $this->assertSame('BAAAAHbYAAA4skAJl8HevRCfRb8', $cbQuery->getInlineMessageId());
             $this->assertSame('777777777777777777', $cbQuery->getChatInstance());
             $this->assertSame('ok', $cbQuery->getData());
+            $this->assertTrue($ctx->isCallbackQuery());
         });
 
         $bot->run();
     }
-
-    public function testCbQueryFallbackIfNoListenersAreFound()
-    {
-        $config = new Config();
-        $config->setUpdateMode(Config::WEBHOOK_MODE);
-        $config->setUpdateStream(__DIR__ . '/../update_types/callback_query.json');
-        $bot = new Zanzara("test", $config);
-
-        $bot->onCbQueryData(['read', 'write'], function (Context $ctx) {
-            $this->assertCallbackQuery($ctx->getCallbackQuery());
-        });
-
-        $bot->fallback(function (Context $ctx) {
-            throw new \Exception();
-        });
-
-        $bot->run();
-
-    }
-
 }

--- a/tests/Listener/CallbackQueryTest.php
+++ b/tests/Listener/CallbackQueryTest.php
@@ -104,4 +104,23 @@ class CallbackQueryTest extends TestCase
         $bot->run();
     }
 
+    public function testCbQueryFallbackIfNoListenersAreFound()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setUpdateStream(__DIR__ . '/../update_types/callback_query.json');
+        $bot = new Zanzara("test", $config);
+
+        $bot->onCbQueryData(['read', 'write'], function (Context $ctx) {
+            $this->assertCallbackQuery($ctx->getCallbackQuery());
+        });
+
+        $bot->fallback(function (Context $ctx) {
+            throw new \Exception();
+        });
+
+        $bot->run();
+
+    }
+
 }

--- a/tests/Middleware/MiddlewareTest.php
+++ b/tests/Middleware/MiddlewareTest.php
@@ -44,4 +44,23 @@ class MiddlewareTest extends TestCase
         $bot->run();
     }
 
+    public function testMiddlewareOnFallback()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setUpdateStream(__DIR__ . '/../update_types/command.json');
+        $bot = new Zanzara("test", $config);
+
+        $bot->middleware(function (Context $ctx, $next) {
+            $ctx->set('exec', true);
+            $next($ctx);
+        });
+
+        $bot->fallback(function (Context $ctx) {
+            $this->assertNotNull($ctx->get('exec'));
+        });
+
+        $bot->run();
+    }
+
 }


### PR DESCRIPTION
Apply some fixes to the latest addition: if a listener if found for callback queries, no need to call the fallback method, and all the global middlewares should be applied to the fallback listener.