### PR TITLE
Support regex as dynamic parameters

### DIFF
--- a/src/Zanzara/Listener/Listener.php
+++ b/src/Zanzara/Listener/Listener.php
@@ -29,9 +29,14 @@ class Listener extends MiddlewareCollector implements MiddlewareInterface
     protected $callback;
 
     /**
+     * @var array
+     */
+    protected $parameters = [];
+
+    /**
      * @param  $callback
-     * @param  ContainerInterface  $container
-     * @param  string|null  $id
+     * @param ContainerInterface $container
+     * @param string|null $id
      * @throws \DI\DependencyException
      * @throws \DI\NotFoundException
      */
@@ -48,7 +53,8 @@ class Listener extends MiddlewareCollector implements MiddlewareInterface
      */
     public function handle(Context $ctx, $next)
     {
-        call_user_func($this->callback, $ctx, $next);
+        $parameters = array_merge([$ctx], $this->parameters, [$next]);
+        call_user_func_array($this->callback, $parameters);
     }
 
     /**
@@ -57,6 +63,16 @@ class Listener extends MiddlewareCollector implements MiddlewareInterface
     public function getTip(): MiddlewareNode
     {
         return $this->tip;
+    }
+
+    /**
+     * @param array $parameters
+     * @return Listener
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+        return $this;
     }
 
 }

--- a/src/Zanzara/Listener/Listener.php
+++ b/src/Zanzara/Listener/Listener.php
@@ -53,8 +53,7 @@ class Listener extends MiddlewareCollector implements MiddlewareInterface
      */
     public function handle(Context $ctx, $next)
     {
-        $parameters = array_merge([$ctx], $this->parameters, [$next]);
-        call_user_func_array($this->callback, $parameters);
+        call_user_func($this->callback, $ctx, ...array_merge($this->parameters, [$next]));
     }
 
     /**

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -78,7 +78,9 @@ abstract class ListenerCollector
      */
     public function onCommand(string $command, $callback): MiddlewareCollector
     {
-        $command = "/^\/$command$/";
+        $pattern = str_replace('/', '\/', "/{$command}");
+        $command = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/', '(?<$1>.*)', $pattern).' ?$/miu';
+
         $listener = new Listener($callback, $this->container, $command);
         $this->listeners['messages'][$command] = $listener;
         return $listener;

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -177,7 +177,7 @@ abstract class ListenerCollector
      */
     public function onCbQueryText(string $text, $callback): MiddlewareCollector
     {
-        $text = "/$text/";
+        $text = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu', '(?<$1>.*)', $text).' ?$/miu';
         $listener = new Listener($callback, $this->container, $text);
         $this->listeners['cb_query_texts'][$text] = $listener;
         return $listener;

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -31,6 +31,13 @@ use Zanzara\Telegram\Type\Update;
  */
 abstract class ListenerCollector
 {
+    /**
+     * Match every parameter in the form of: {param}
+     * Doesn't match number paramenters, like {12},
+     * to keep allow regex with quantifiers as command/text
+     * listeners.
+     */
+    protected const PARAMETER_REGEX = '/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu';
 
     /**
      * Associative array for listeners.
@@ -79,7 +86,7 @@ abstract class ListenerCollector
     public function onCommand(string $command, $callback): MiddlewareCollector
     {
         $pattern = str_replace('/', '\/', "/{$command}");
-        $command = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu', '(?<$1>.*)', $pattern).' ?$/miu';
+        $command = '/^'.preg_replace(self::PARAMETER_REGEX, '(?<$1>.*)', $pattern).' ?$/miu';
 
         $listener = new Listener($callback, $this->container, $command);
         $this->listeners['messages'][$command] = $listener;
@@ -101,7 +108,7 @@ abstract class ListenerCollector
      */
     public function onText(string $text, $callback): MiddlewareCollector
     {
-        $text = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu', '(?<$1>.*)', $text).' ?$/miu';
+        $text = '/^'.preg_replace(self::PARAMETER_REGEX, '(?<$1>.*)', $text).' ?$/miu';
         $listener = new Listener($callback, $this->container, $text);
         $this->listeners['messages'][$text] = $listener;
         return $listener;
@@ -177,7 +184,7 @@ abstract class ListenerCollector
      */
     public function onCbQueryText(string $text, $callback): MiddlewareCollector
     {
-        $text = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu', '(?<$1>.*)', $text).' ?$/miu';
+        $text = '/^'.preg_replace(self::PARAMETER_REGEX, '(?<$1>.*)', $text).' ?$/miu';
         $listener = new Listener($callback, $this->container, $text);
         $this->listeners['cb_query_texts'][$text] = $listener;
         return $listener;

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -33,7 +33,7 @@ abstract class ListenerCollector
 {
     /**
      * Match every parameter in the form of: {param}
-     * Doesn't match number paramenters, like {12},
+     * Doesn't match number parameters, like {12},
      * to keep allow regex with quantifiers as command/text
      * listeners.
      */
@@ -77,6 +77,9 @@ abstract class ListenerCollector
      * Listen for the specified command.
      * Eg. $bot->onCommand('start', function(Context $ctx) {});
      *
+     * You can also parameterized the command, eg:
+     * Eg. $bot->onCommand('start {myParam}', function(Context $ctx, $myParam) {});
+     *
      * @param  string  $command
      * @param $callback
      * @return MiddlewareCollector
@@ -99,6 +102,9 @@ abstract class ListenerCollector
      *
      * Text is a regex, so you could also do something like:
      * $bot->onText('[a-zA-Z]{15}?', function(Context $ctx) {});
+     *
+     * You can also parameterized the text, eg:
+     * Eg. $bot->onText('Hello {name}', function(Context $ctx, $name) {});
      *
      * @param  string  $text
      * @param  $callback
@@ -175,6 +181,9 @@ abstract class ListenerCollector
      *
      * Text is a regex, so you could also do something like:
      * $bot->onCbQueryText('[a-zA-Z]{27}?', function(Context $ctx) {});
+     *
+     * You can also parameterized the text, eg:
+     * Eg. $bot->onCbQueryText('Hello {name}', function(Context $ctx, $name) {});
      *
      * @param  string  $text
      * @param  $callback

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -79,7 +79,7 @@ abstract class ListenerCollector
     public function onCommand(string $command, $callback): MiddlewareCollector
     {
         $pattern = str_replace('/', '\/', "/{$command}");
-        $command = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/', '(?<$1>.*)', $pattern).' ?$/miu';
+        $command = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu', '(?<$1>.*)', $pattern).' ?$/miu';
 
         $listener = new Listener($callback, $this->container, $command);
         $this->listeners['messages'][$command] = $listener;
@@ -101,7 +101,7 @@ abstract class ListenerCollector
      */
     public function onText(string $text, $callback): MiddlewareCollector
     {
-        $text = "/$text/";
+        $text = '/^'.preg_replace('/\{((?:(?!\d+,?\d+?)\w)+?)\}/miu', '(?<$1>.*)', $text).' ?$/miu';
         $listener = new Listener($callback, $this->container, $text);
         $this->listeners['messages'][$text] = $listener;
         return $listener;

--- a/src/Zanzara/Listener/ListenerResolver.php
+++ b/src/Zanzara/Listener/ListenerResolver.php
@@ -108,8 +108,10 @@ abstract class ListenerResolver extends ListenerCollector
         if ($listenerId !== null) {
             $typedListeners = $this->listeners[$listenerType] ?? [];
             foreach ($typedListeners as $regex => $listener) {
-                if (preg_match($regex, $listenerId)) {
-                    $listeners[] = $listener;
+                $regexMatched = (bool) preg_match($regex, $listenerId, $matches, PREG_UNMATCHED_AS_NULL);
+                if ($regexMatched) {
+                    $parameters = array_unique(array_values(array_slice($matches, 1)));
+                    $listeners[] = $listener->setParameters($parameters);
                     return $listener;
                 }
             }

--- a/tests/Listener/CallbackQueryTest.php
+++ b/tests/Listener/CallbackQueryTest.php
@@ -104,4 +104,19 @@ class CallbackQueryTest extends TestCase
 
         $bot->run();
     }
+
+    public function testCbQueryTextWithParameters()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setUpdateStream(__DIR__ . '/../update_types/callback_query.json');
+        $bot = new Zanzara("test", $config);
+
+        $bot->onCbQueryText("Manage your {param}", function (Context $ctx, $param) {
+            $this->assertSame('data', $param);
+        });
+
+        $bot->run();
+    }
+
 }

--- a/tests/Listener/CommandTest.php
+++ b/tests/Listener/CommandTest.php
@@ -83,4 +83,40 @@ class CommandTest extends TestCase
         $bot->run();
     }
 
+    public function testCommandWithParameters()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setUpdateStream(__DIR__ . '/../update_types/command_parameters.json');
+        $bot = new Zanzara("test", $config);
+
+        $bot->onCommand('start {param} {otherParam}', function (Context $ctx, $param, $otherParam) {
+            $update = $ctx->getUpdate();
+            $message = $update->getMessage();
+            $this->assertSame(52259544, $update->getUpdateId());
+            $this->assertSame(23756, $message->getMessageId());
+            $this->assertSame(222222222, $message->getFrom()->getId());
+            $this->assertSame(false, $message->getFrom()->isBot());
+            $this->assertSame('Michael', $message->getFrom()->getFirstName());
+            $this->assertSame('mscott', $message->getFrom()->getUsername());
+            $this->assertSame('it', $message->getFrom()->getLanguageCode());
+            $this->assertSame(222222222, $message->getChat()->getId());
+            $this->assertSame('Michael', $message->getChat()->getFirstName());
+            $this->assertSame('mscott', $message->getChat()->getUsername());
+            $this->assertSame('private', $message->getChat()->getType());
+            $this->assertSame(1584984664, $message->getDate());
+            $this->assertSame('/start ciao hello', $message->getText());
+            $this->assertSame('ciao', $param);
+            $this->assertSame('hello', $otherParam);
+            $this->assertCount(1, $message->getEntities());
+            $entity = $message->getEntities()[0];
+            $this->assertInstanceOf(MessageEntity::class, $entity);
+            $this->assertEquals(0, $entity->getOffset());
+            $this->assertEquals(6, $entity->getLength());
+            $this->assertEquals('bot_command', $entity->getType());
+        });
+
+        $bot->run();
+    }
+
 }

--- a/tests/Listener/RegexTest.php
+++ b/tests/Listener/RegexTest.php
@@ -77,6 +77,34 @@ class RegexTest extends TestCase
         $bot->run();
     }
 
+    public function testTextWithParameters()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setUpdateStream(__DIR__ . '/../update_types/message.json');
+        $bot = new Zanzara('test', $config);
+
+        $bot->onText('(?<param>[a-zA-Z]{5})', function (Context $ctx, $param) {
+            $message = $ctx->getMessage();
+            $this->assertSame(52259544, $ctx->getUpdateId());
+            $this->assertSame(23756, $message->getMessageId());
+            $this->assertSame(222222222, $message->getFrom()->getId());
+            $this->assertSame(false, $message->getFrom()->isBot());
+            $this->assertSame('Michael', $message->getFrom()->getFirstName());
+            $this->assertSame('mscott', $message->getFrom()->getUsername());
+            $this->assertSame('it', $message->getFrom()->getLanguageCode());
+            $this->assertSame(222222222, $message->getChat()->getId());
+            $this->assertSame('Michael', $message->getChat()->getFirstName());
+            $this->assertSame('mscott', $message->getChat()->getUsername());
+            $this->assertSame('private', $message->getChat()->getType());
+            $this->assertSame(1584984664, $message->getDate());
+            $this->assertSame('Hello', $message->getText());
+            $this->assertSame('Hello', $param);
+        });
+
+        $bot->run();
+    }
+
     public function testCallbackQuery()
     {
         $config = new Config();

--- a/tests/Listener/RegexTest.php
+++ b/tests/Listener/RegexTest.php
@@ -57,7 +57,7 @@ class RegexTest extends TestCase
         $config->setUpdateStream(__DIR__ . '/../update_types/message.json');
         $bot = new Zanzara('test', $config);
 
-        $bot->onText('[a-zA-Z]{5}', function (Context $ctx) {
+        $bot->onText('([a-zA-Z]+)', function (Context $ctx) {
             $message = $ctx->getMessage();
             $this->assertSame(52259544, $ctx->getUpdateId());
             $this->assertSame(23756, $message->getMessageId());
@@ -77,14 +77,14 @@ class RegexTest extends TestCase
         $bot->run();
     }
 
-    public function testTextWithParameters()
+    public function testTextWithParametersRegex()
     {
         $config = new Config();
         $config->setUpdateMode(Config::WEBHOOK_MODE);
         $config->setUpdateStream(__DIR__ . '/../update_types/message.json');
         $bot = new Zanzara('test', $config);
 
-        $bot->onText('(?<param>[a-zA-Z]{5})', function (Context $ctx, $param) {
+        $bot->onText('(?<param>[a-zA-Z]+)', function (Context $ctx, $param) {
             $message = $ctx->getMessage();
             $this->assertSame(52259544, $ctx->getUpdateId());
             $this->assertSame(23756, $message->getMessageId());
@@ -100,6 +100,36 @@ class RegexTest extends TestCase
             $this->assertSame(1584984664, $message->getDate());
             $this->assertSame('Hello', $message->getText());
             $this->assertSame('Hello', $param);
+        });
+
+        $bot->run();
+    }
+
+    public function testTextWithParametersNoRegex()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setUpdateStream(__DIR__ . '/../update_types/command_parameters.json');
+        $bot = new Zanzara('test', $config);
+
+        $bot->onText('{command} {param1} {param2}', function (Context $ctx, $command, $param1, $param2) {
+            $message = $ctx->getMessage();
+            $this->assertSame(52259544, $ctx->getUpdateId());
+            $this->assertSame(23756, $message->getMessageId());
+            $this->assertSame(222222222, $message->getFrom()->getId());
+            $this->assertSame(false, $message->getFrom()->isBot());
+            $this->assertSame('Michael', $message->getFrom()->getFirstName());
+            $this->assertSame('mscott', $message->getFrom()->getUsername());
+            $this->assertSame('it', $message->getFrom()->getLanguageCode());
+            $this->assertSame(222222222, $message->getChat()->getId());
+            $this->assertSame('Michael', $message->getChat()->getFirstName());
+            $this->assertSame('mscott', $message->getChat()->getUsername());
+            $this->assertSame('private', $message->getChat()->getType());
+            $this->assertSame(1584984664, $message->getDate());
+            $this->assertSame('/start ciao hello', $message->getText());
+            $this->assertSame('/start', $command);
+            $this->assertSame('ciao', $param1);
+            $this->assertSame('hello', $param2);
         });
 
         $bot->run();

--- a/tests/update_types/command_parameters.json
+++ b/tests/update_types/command_parameters.json
@@ -1,0 +1,28 @@
+{
+    "update_id": 52259544,
+    "message": {
+        "message_id": 23756,
+        "from": {
+            "id": 222222222,
+            "is_bot": false,
+            "first_name": "Michael",
+            "username": "mscott",
+            "language_code": "it"
+        },
+        "chat": {
+            "id": 222222222,
+            "first_name": "Michael",
+            "username": "mscott",
+            "type": "private"
+        },
+        "date": 1584984664,
+        "text": "/start ciao hello",
+        "entities": [
+            {
+                "offset": 0,
+                "length": 6,
+                "type": "bot_command"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This pr aims to add the support to simple parameters for the callable of commands and text events, like:

```php
$bot->onText('My name is {name}, I live in {city}', function (Context $ctx, $name, $city) { ... });
// and
$bot->onCommand('start {token}', function (Context $ctx, $token) { ... });
```
As always, suggestions/changes are welcome