### PR TITLE
Apply global middlewares to conversation handlers

### DIFF
--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -480,14 +480,27 @@ abstract class ListenerCollector
      * Add cross-request middleware to each listener middleware chain.
      *
      */
-    protected function feedMiddlewareStack()
+    protected function applyMiddlewareStack()
     {
         array_walk_recursive($this->listeners, function ($value) {
             if ($value instanceof Listener) {
-                foreach ($this->middleware as $m) {
-                    $value->middleware($m);
-                }
+                $this->feedMiddlewareStack($value);
             }
         });
+    }
+
+    /**
+     * Add cross-request middlewares to a listener.
+     * @param  Listener  $listener
+     * @return Listener
+     * @throws DependencyException
+     * @throws NotFoundException
+     */
+    protected function feedMiddlewareStack(Listener $listener): Listener
+    {
+        foreach ($this->middleware as $m) {
+            $listener->middleware($m);
+        }
+        return $listener;
     }
 }

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -480,11 +480,11 @@ abstract class ListenerCollector
      * Add cross-request middleware to each listener middleware chain.
      *
      */
-    protected function applyMiddlewareStack()
+    protected function feedMiddlewareStack()
     {
         array_walk_recursive($this->listeners, function ($value) {
             if ($value instanceof Listener) {
-                $this->feedMiddlewareStack($value);
+                $this->applyMiddlewareStack($value);
             }
         });
     }
@@ -496,7 +496,7 @@ abstract class ListenerCollector
      * @throws DependencyException
      * @throws NotFoundException
      */
-    protected function feedMiddlewareStack(Listener $listener): Listener
+    protected function applyMiddlewareStack(Listener $listener): Listener
     {
         foreach ($this->middleware as $m) {
             $listener->middleware($m);

--- a/src/Zanzara/Listener/ListenerResolver.php
+++ b/src/Zanzara/Listener/ListenerResolver.php
@@ -49,7 +49,7 @@ abstract class ListenerResolver extends ListenerCollector
                             $this->findListenerAndPush($listeners, 'cb_query_texts', $text, true);
                         }
                     } else { // if we are in a conversation, redirect it only to the conversation step
-                        $listeners[] = new Listener($handlerInfo[0], $this->container);
+                        $listeners[] = $this->applyMiddlewareStack(new Listener($handlerInfo[0], $this->container));
                     }
                     $deferred->resolve($listeners);
                 })->otherwise(function ($e) use ($deferred) {
@@ -77,7 +77,7 @@ abstract class ListenerResolver extends ListenerCollector
                         }
                     }
                     if ($callback) {
-                        $listeners[] = new Listener($callback, $this->container);
+                        $listeners[] = $this->applyMiddlewareStack(new Listener($callback, $this->container));
                     }
                     $deferred->resolve($listeners);
                 })->otherwise(function ($e) use ($deferred) {

--- a/src/Zanzara/Zanzara.php
+++ b/src/Zanzara/Zanzara.php
@@ -84,7 +84,7 @@ class Zanzara extends ListenerResolver
 
     public function run(): void
     {
-        $this->applyMiddlewareStack();
+        $this->feedMiddlewareStack();
         // we set "string|UpdateModeInterface" as return type just to have IDE suggestions, actually it is always a string
         $this->container->get(/** @scrutinizer ignore-type */ $this->config->getUpdateMode())->run();
         $this->loop->run();

--- a/src/Zanzara/Zanzara.php
+++ b/src/Zanzara/Zanzara.php
@@ -84,7 +84,7 @@ class Zanzara extends ListenerResolver
 
     public function run(): void
     {
-        $this->feedMiddlewareStack();
+        $this->applyMiddlewareStack();
         // we set "string|UpdateModeInterface" as return type just to have IDE suggestions, actually it is always a string
         $this->container->get(/** @scrutinizer ignore-type */ $this->config->getUpdateMode())->run();
         $this->loop->run();


### PR DESCRIPTION
When starting a conversation, all the data pushed in the context by the handlers, works as expected, but when going to the next step in a conversation, the global middlewares are not called anymore, because the listener is created on-the-fly. 
This pr should address this issue.