### PR TITLE
Fix conversation with global middleware

### DIFF
--- a/src/Zanzara/Config.php
+++ b/src/Zanzara/Config.php
@@ -138,6 +138,11 @@ class Config
     private $cacheTtl = 180;
 
     /**
+     * @var float|null
+     */
+    private $conversationTtl = 60 * 60 * 24;
+
+    /**
      * @var Connector|null
      */
     private $connector;
@@ -529,6 +534,22 @@ class Config
     public function setProxyHttpHeaders(array $proxyHttpHeaders): void
     {
         $this->proxyHttpHeaders = $proxyHttpHeaders;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getConversationTtl(): ?float
+    {
+        return $this->conversationTtl;
+    }
+
+    /**
+     * @param float|null $conversationTtl
+     */
+    public function setConversationTtl(?float $conversationTtl): void
+    {
+        $this->conversationTtl = $conversationTtl;
     }
 
 }

--- a/src/Zanzara/Context.php
+++ b/src/Zanzara/Context.php
@@ -123,17 +123,18 @@ class Context
      *
      * This callable must be take on parameter of type Context
      * @param $handler
-     * @param bool $skipListeners if true the conversation handler has precedence over the listeners, so the listener
+     * @param  bool  $skipListeners  if true the conversation handler has precedence over the listeners, so the listener
      * callbacks are not executed.
+     * @param  bool  $skipMiddlewares if true, the next conversation handler will be called without apply middlewares
      * @return PromiseInterface
      * @throws \DI\DependencyException
      * @throws \DI\NotFoundException
      */
-    public function nextStep($handler, bool $skipListeners = false): PromiseInterface
+    public function nextStep($handler, bool $skipListeners = false, bool $skipMiddlewares = false): PromiseInterface
     {
         // update is not null when used within the Context
         $chatId = $this->update->/** @scrutinizer ignore-call */ getEffectiveChat()->getId();
-        return $this->conversationManager->setConversationHandler($chatId, $this->getCallable($handler), $skipListeners);
+        return $this->conversationManager->setConversationHandler($chatId, $this->getCallable($handler), $skipListeners, $skipMiddlewares);
     }
 
     /**

--- a/src/Zanzara/ConversationManager.php
+++ b/src/Zanzara/ConversationManager.php
@@ -14,7 +14,9 @@ use React\Promise\PromiseInterface;
 class ConversationManager
 {
 
-    private const CONVERSATION = 'CONVERSATION_';
+    private const CONVERSATION = 'CONVERSATION';
+
+    private const CONVERSATION_CACHE_TIME = 60 * 60 * 24;
 
     /**
      * @var ZanzaraCache
@@ -33,7 +35,7 @@ class ConversationManager
      */
     private function getConversationKey($chatId): string
     {
-        return self::CONVERSATION . strval($chatId);
+        return self::CONVERSATION . '_' . strval($chatId);
     }
 
     public function setConversationHandler($chatId, $handler, bool $skipListeners, bool $skipMiddlewares): PromiseInterface
@@ -43,7 +45,7 @@ class ConversationManager
         if ($handler instanceof Closure) {
             $handler = new SerializableClosure($handler);
         }
-        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners, $skipMiddlewares]);
+        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners, $skipMiddlewares], self::CONVERSATION_CACHE_TIME);
     }
 
     public function getConversationHandler($chatId): PromiseInterface

--- a/src/Zanzara/ConversationManager.php
+++ b/src/Zanzara/ConversationManager.php
@@ -16,16 +16,20 @@ class ConversationManager
 
     private const CONVERSATION = 'CONVERSATION';
 
-    private const CONVERSATION_CACHE_TIME = 60 * 60 * 24;
-
     /**
      * @var ZanzaraCache
      */
     private $cache;
 
-    public function __construct(ZanzaraCache $cache)
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(ZanzaraCache $cache, Config $config)
     {
         $this->cache = $cache;
+        $this->config = $config;
     }
 
     /**
@@ -45,7 +49,7 @@ class ConversationManager
         if ($handler instanceof Closure) {
             $handler = new SerializableClosure($handler);
         }
-        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners, $skipMiddlewares], self::CONVERSATION_CACHE_TIME);
+        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners, $skipMiddlewares], $this->config->getConversationTtl());
     }
 
     public function getConversationHandler($chatId): PromiseInterface

--- a/src/Zanzara/ConversationManager.php
+++ b/src/Zanzara/ConversationManager.php
@@ -14,7 +14,7 @@ use React\Promise\PromiseInterface;
 class ConversationManager
 {
 
-    private const CONVERSATION = "CONVERSATION";
+    private const CONVERSATION = 'CONVERSATION_';
 
     /**
      * @var ZanzaraCache
@@ -36,30 +36,30 @@ class ConversationManager
         return self::CONVERSATION . strval($chatId);
     }
 
-    public function setConversationHandler($chatId, $handler, bool $skipListeners): PromiseInterface
+    public function setConversationHandler($chatId, $handler, bool $skipListeners, bool $skipMiddlewares): PromiseInterface
     {
-        $key = "state";
+        $key = 'state';
         $cacheKey = $this->getConversationKey($chatId);
         if ($handler instanceof Closure) {
             $handler = new SerializableClosure($handler);
         }
-        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners]);
+        return $this->cache->doSet($cacheKey, $key, [serialize($handler), $skipListeners, $skipMiddlewares]);
     }
 
     public function getConversationHandler($chatId): PromiseInterface
     {
         return $this->cache->get($this->getConversationKey($chatId))
             ->then(function ($conversation) {
-                if (empty($conversation["state"])) {
+                if (empty($conversation['state'])) {
                     return null;
                 }
 
-                $handler = $conversation["state"][0];
+                $handler = $conversation['state'][0];
                 $handler = unserialize($handler);
                 if ($handler instanceof SerializableClosure) {
                     $handler = $handler->getClosure();
                 }
-                return [$handler, $conversation["state"][1]];
+                return [$handler, $conversation['state'][1], $conversation['state'][2]];
             });
     }
 

--- a/src/Zanzara/ZanzaraCache.php
+++ b/src/Zanzara/ZanzaraCache.php
@@ -33,11 +33,11 @@ class ZanzaraCache
      */
     private $config;
 
-    private const CHATDATA = "CHATDATA";
+    private const CHATDATA = 'CHATDATA';
 
-    private const USERDATA = "USERDATA";
+    private const USERDATA = 'USERDATA';
 
-    private const GLOBALDATA = "GLOBALDATA";
+    private const GLOBALDATA = 'GLOBALDATA';
 
     /**
      * ZanzaraLogger constructor.
@@ -95,7 +95,7 @@ class ZanzaraCache
      */
     private function getChatIdKey(int $chatId)
     {
-        return ZanzaraCache::CHATDATA . strval($chatId);
+        return ZanzaraCache::CHATDATA . '_' . strval($chatId);
     }
 
     public function getCacheChatData(int $chatId)
@@ -141,7 +141,7 @@ class ZanzaraCache
      */
     private function getUserIdKey(int $userId)
     {
-        return ZanzaraCache::USERDATA . strval($userId);
+        return ZanzaraCache::USERDATA . '_' . strval($userId);
     }
 
     public function getCacheUserData(int $userId)


### PR DESCRIPTION
At first glance this may seem unnecessary given the last pr, but explained with an example it is simpler:
I would like for example to have a global middleware that takes from the database the user by telegram_id and puts it in the context, and if it is not there in the database, it asks him a question that he has to answer (so opening a mini conversation with `nextStep(...)`) and then saves it to database.
This is not possible anymore, since now all global middleware is always applied to all conversation handlers, and basically you enter the loop where the bot asks you always the same question, because the middleware is called before the conversation handler. You can avoid this by not using global middleware, but that means having to apply it to every listener by hand (with `->middleware(...)`), which makes the code redundant and defeats the benefit of global middleware. 

In this pr is what I came up with to make middlewares optional for certain conversation flows.

It also add some `_` in the cache keys because now are kinda hard to read when debugging