### PR TITLE
Add Retry Feature To TelegramTraits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "badfarm/zanzara",
+    "name": "parsoolak/zanzara",
     "type": "library",
     "description": "Asynchronous PHP Telegram Bot Framework",
     "keywords": [

--- a/src/Zanzara/Telegram/TelegramTrait.php
+++ b/src/Zanzara/Telegram/TelegramTrait.php
@@ -2552,9 +2552,10 @@ trait TelegramTrait
                 else
                     $time = 30;
 
+                echo "**** -> Going to Retry $time".PHP_EOL;
                 return \React\Promise\Timer\sleep($time)
                     ->then(function () use (&$text, &$opt, &$retryCount) {
-                        return $this->sendMessageRetry($text, $opt, $retryCount - 1);
+                        return $this->sendMessageWithRetry($text, $opt, $retryCount - 1);
                     });
             });
     }

--- a/src/Zanzara/Telegram/TelegramTrait.php
+++ b/src/Zanzara/Telegram/TelegramTrait.php
@@ -2552,7 +2552,6 @@ trait TelegramTrait
                 else
                     $time = 30;
 
-                echo "**** -> Going to Retry $time".PHP_EOL;
                 return \React\Promise\Timer\sleep($time)
                     ->then(function () use (&$text, &$opt, &$retryCount) {
                         return $this->sendMessageWithRetry($text, $opt, $retryCount - 1);


### PR DESCRIPTION
This feature helps you to avoid Telegram Flood when you sending a lot of messages. it automatically waits for the requested time that telegram tells otherwise it will wait for 30 seconds and try again. you can also customize how many retries it should do.

Can you guys review this PR?