### PR TITLE
New functionalities for Cache & MessageQueue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-readline": "*",
         "react/event-loop": "^1.3",
         "react/http": "^1.8",
-        "psr/log": "^1.1",
+        "psr/log": "^3.0",
         "psr/container": "^1.1",
         "php-di/php-di": "^6.4",
         "react/cache": "^1.2",
@@ -53,7 +53,7 @@
     },
     "config": {
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": false
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-json": "*",
         "ext-readline": "*",
         "react/event-loop": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87eeace13e7024a0b152bd271896d99e",
+    "content-hash": "e4986815090297e25caca6b96b7c8e3e",
     "packages": [
         {
             "name": "clue/http-proxy-react",
@@ -527,16 +527,16 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.15.3",
+            "version": "1.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "3ccd28dd9fb34b52db946abea1b538568e34eae8"
+                "reference": "57f3de01d32085fea20865f9b16fb0e69347c39e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/3ccd28dd9fb34b52db946abea1b538568e34eae8",
-                "reference": "3ccd28dd9fb34b52db946abea1b538568e34eae8",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/57f3de01d32085fea20865f9b16fb0e69347c39e",
+                "reference": "57f3de01d32085fea20865f9b16fb0e69347c39e",
                 "shasum": ""
             },
             "require": {
@@ -544,7 +544,8 @@
                 "php": "^7.1 || ^8.0"
             },
             "conflict": {
-                "nyholm/psr7": "<1.0"
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
             },
             "provide": {
                 "php-http/async-client-implementation": "*",
@@ -569,7 +570,10 @@
             "autoload": {
                 "psr-4": {
                     "Http\\Discovery\\": "src/"
-                }
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -595,96 +599,36 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.15.3"
+                "source": "https://github.com/php-http/discovery/tree/1.19.1"
             },
-            "time": "2023-03-31T14:40:37+00:00"
-        },
-        {
-            "name": "php-http/message-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/message-factory.git",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message-factory/zipball/4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Factory interfaces for PSR-7 HTTP Message",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "stream",
-                "uri"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/message-factory/issues",
-                "source": "https://github.com/php-http/message-factory/tree/1.1.0"
-            },
-            "time": "2023-04-14T14:16:17+00:00"
+            "time": "2023-07-11T07:02:26+00:00"
         },
         {
             "name": "php-http/multipart-stream-builder",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/multipart-stream-builder.git",
-                "reference": "11c1d31f72e01c738bbce9e27649a7cca829c30e"
+                "reference": "f5938fd135d9fa442cc297dc98481805acfe2b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/11c1d31f72e01c738bbce9e27649a7cca829c30e",
-                "reference": "11c1d31f72e01c738bbce9e27649a7cca829c30e",
+                "url": "https://api.github.com/repos/php-http/multipart-stream-builder/zipball/f5938fd135d9fa442cc297dc98481805acfe2b6a",
+                "reference": "f5938fd135d9fa442cc297dc98481805acfe2b6a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0",
-                "php-http/discovery": "^1.7",
-                "php-http/message-factory": "^1.0.2",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0"
+                "php-http/discovery": "^1.15",
+                "psr/http-factory-implementation": "^1.0"
             },
             "require-dev": {
                 "nyholm/psr7": "^1.0",
                 "php-http/message": "^1.5",
+                "php-http/message-factory": "^1.0.2",
                 "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Http\\Message\\MultipartStream\\": "src/"
@@ -711,9 +655,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/multipart-stream-builder/issues",
-                "source": "https://github.com/php-http/multipart-stream-builder/tree/1.2.0"
+                "source": "https://github.com/php-http/multipart-stream-builder/tree/1.3.0"
             },
-            "time": "2021-05-21T08:32:01+00:00"
+            "time": "2023-04-28T14:10:22+00:00"
         },
         {
             "name": "psr/container",
@@ -762,61 +706,6 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
             "time": "2021-11-05T16:50:12+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
-            },
-            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
@@ -873,30 +762,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -917,9 +806,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "react/cache",
@@ -995,33 +884,33 @@
         },
         {
             "name": "react/dns",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/dns.git",
-                "reference": "a5427e7dfa47713e438016905605819d101f238c"
+                "reference": "3be0fc8f1eb37d6875cd6f0c6c7d0be81435de9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/dns/zipball/a5427e7dfa47713e438016905605819d101f238c",
-                "reference": "a5427e7dfa47713e438016905605819d101f238c",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/3be0fc8f1eb37d6875cd6f0c6c7d0be81435de9f",
+                "reference": "3be0fc8f1eb37d6875cd6f0c6c7d0be81435de9f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0",
                 "react/cache": "^1.0 || ^0.6 || ^0.5",
                 "react/event-loop": "^1.2",
-                "react/promise": "^3.0 || ^2.7 || ^1.2.1",
-                "react/promise-timer": "^1.9"
+                "react/promise": "^3.0 || ^2.7 || ^1.2.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^4.8.35",
-                "react/async": "^4 || ^3 || ^2"
+                "phpunit/phpunit": "^9.5 || ^4.8.35",
+                "react/async": "^4 || ^3 || ^2",
+                "react/promise-timer": "^1.9"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "React\\Dns\\": "src"
+                    "React\\Dns\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1059,49 +948,43 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/dns/issues",
-                "source": "https://github.com/reactphp/dns/tree/v1.10.0"
+                "source": "https://github.com/reactphp/dns/tree/v1.11.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-09-08T12:22:46+00:00"
+            "time": "2023-06-02T12:45:26+00:00"
         },
         {
             "name": "react/event-loop",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "187fb56f46d424afb6ec4ad089269c72eec2e137"
+                "reference": "6e7e587714fff7a83dcc7025aee42ab3b265ae05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/187fb56f46d424afb6ec4ad089269c72eec2e137",
-                "reference": "187fb56f46d424afb6ec4ad089269c72eec2e137",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/6e7e587714fff7a83dcc7025aee42ab3b265ae05",
+                "reference": "6e7e587714fff7a83dcc7025aee42ab3b265ae05",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "suggest": {
-                "ext-event": "~1.0 for ExtEventLoop",
-                "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
-                "ext-uv": "* for ExtUvLoop"
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "React\\EventLoop\\": "src"
+                    "React\\EventLoop\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1137,32 +1020,28 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.3.0"
+                "source": "https://github.com/reactphp/event-loop/tree/v1.4.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-03-17T11:10:22+00:00"
+            "time": "2023-05-05T10:11:24+00:00"
         },
         {
             "name": "react/http",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/http.git",
-                "reference": "aa7512ee17258c88466de30f9cb44ec5f9df3ff3"
+                "reference": "bb3154dbaf2dfe3f0467f956a05f614a69d5f1d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http/zipball/aa7512ee17258c88466de30f9cb44ec5f9df3ff3",
-                "reference": "aa7512ee17258c88466de30f9cb44ec5f9df3ff3",
+                "url": "https://api.github.com/repos/reactphp/http/zipball/bb3154dbaf2dfe3f0467f956a05f614a69d5f1d0",
+                "reference": "bb3154dbaf2dfe3f0467f956a05f614a69d5f1d0",
                 "shasum": ""
             },
             "require": {
@@ -1172,7 +1051,6 @@
                 "psr/http-message": "^1.0",
                 "react/event-loop": "^1.2",
                 "react/promise": "^3 || ^2.3 || ^1.2.1",
-                "react/promise-stream": "^1.4",
                 "react/socket": "^1.12",
                 "react/stream": "^1.2",
                 "ringcentral/psr7": "^1.2"
@@ -1181,14 +1059,15 @@
                 "clue/http-proxy-react": "^1.8",
                 "clue/reactphp-ssh-proxy": "^1.4",
                 "clue/socks-react": "^1.4",
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
                 "react/async": "^4 || ^3 || ^2",
+                "react/promise-stream": "^1.4",
                 "react/promise-timer": "^1.9"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "React\\Http\\": "src"
+                    "React\\Http\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1233,39 +1112,36 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/http/issues",
-                "source": "https://github.com/reactphp/http/tree/v1.8.0"
+                "source": "https://github.com/reactphp/http/tree/v1.9.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-09-29T12:55:52+00:00"
+            "time": "2023-04-26T10:29:24+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.9.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910"
+                "reference": "c86753c76fd3be465d93b308f18d189f01a22be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/234f8fd1023c9158e2314fa9d7d0e6a83db42910",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/c86753c76fd3be465d93b308f18d189f01a22be4",
+                "reference": "c86753c76fd3be465d93b308f18d189f01a22be4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+                "phpstan/phpstan": "1.10.20 || 1.4.10",
+                "phpunit/phpunit": "^9.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
@@ -1309,213 +1185,43 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
+                "source": "https://github.com/reactphp/promise/tree/v3.0.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-02-11T10:27:51+00:00"
-        },
-        {
-            "name": "react/promise-stream",
-            "version": "v1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise-stream.git",
-                "reference": "e6d2805e09ad50c4896f65f5e8705fe4ee7731a3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise-stream/zipball/e6d2805e09ad50c4896f65f5e8705fe4ee7731a3",
-                "reference": "e6d2805e09ad50c4896f65f5e8705fe4ee7731a3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "react/promise": "^3 || ^2.1 || ^1.2",
-                "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "React\\Promise\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering",
-                    "homepage": "https://clue.engineering/"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "reactphp@ceesjankiewiet.nl",
-                    "homepage": "https://wyrihaximus.net/"
-                },
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com",
-                    "homepage": "https://sorgalla.com/"
-                },
-                {
-                    "name": "Chris Boden",
-                    "email": "cboden@gmail.com",
-                    "homepage": "https://cboden.dev/"
-                }
-            ],
-            "description": "The missing link between Promise-land and Stream-land for ReactPHP",
-            "homepage": "https://github.com/reactphp/promise-stream",
-            "keywords": [
-                "Buffer",
-                "async",
-                "promise",
-                "reactphp",
-                "stream",
-                "unwrap"
-            ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise-stream/issues",
-                "source": "https://github.com/reactphp/promise-stream/tree/v1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-09-09T11:42:18+00:00"
-        },
-        {
-            "name": "react/promise-timer",
-            "version": "v1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise-timer.git",
-                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
-                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "react/event-loop": "^1.2",
-                "react/promise": "^3.0 || ^2.7.0 || ^1.2.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "React\\Promise\\Timer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering",
-                    "homepage": "https://clue.engineering/"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "reactphp@ceesjankiewiet.nl",
-                    "homepage": "https://wyrihaximus.net/"
-                },
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com",
-                    "homepage": "https://sorgalla.com/"
-                },
-                {
-                    "name": "Chris Boden",
-                    "email": "cboden@gmail.com",
-                    "homepage": "https://cboden.dev/"
-                }
-            ],
-            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
-            "homepage": "https://github.com/reactphp/promise-timer",
-            "keywords": [
-                "async",
-                "event-loop",
-                "promise",
-                "reactphp",
-                "timeout",
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise-timer/issues",
-                "source": "https://github.com/reactphp/promise-timer/tree/v1.9.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-06-13T13:41:03+00:00"
+            "time": "2023-07-11T16:12:49+00:00"
         },
         {
             "name": "react/socket",
-            "version": "v1.12.0",
+            "version": "v1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/socket.git",
-                "reference": "81e1b4d7f5450ebd8d2e9a95bb008bb15ca95a7b"
+                "reference": "cff482bbad5848ecbe8b57da57e4e213b03619aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/socket/zipball/81e1b4d7f5450ebd8d2e9a95bb008bb15ca95a7b",
-                "reference": "81e1b4d7f5450ebd8d2e9a95bb008bb15ca95a7b",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/cff482bbad5848ecbe8b57da57e4e213b03619aa",
+                "reference": "cff482bbad5848ecbe8b57da57e4e213b03619aa",
                 "shasum": ""
             },
             "require": {
                 "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
                 "php": ">=5.3.0",
-                "react/dns": "^1.8",
+                "react/dns": "^1.11",
                 "react/event-loop": "^1.2",
                 "react/promise": "^3 || ^2.6 || ^1.2.1",
-                "react/promise-timer": "^1.9",
                 "react/stream": "^1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35",
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
                 "react/async": "^4 || ^3 || ^2",
-                "react/promise-stream": "^1.4"
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.9"
             },
             "type": "library",
             "autoload": {
@@ -1559,32 +1265,28 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/socket/issues",
-                "source": "https://github.com/reactphp/socket/tree/v1.12.0"
+                "source": "https://github.com/reactphp/socket/tree/v1.13.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-08-25T12:32:25+00:00"
+            "time": "2023-06-07T10:28:34+00:00"
         },
         {
             "name": "react/stream",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/stream.git",
-                "reference": "7a423506ee1903e89f1e08ec5f0ed430ff784ae9"
+                "reference": "6fbc9672905c7d5a885f2da2fc696f65840f4a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/7a423506ee1903e89f1e08ec5f0ed430ff784ae9",
-                "reference": "7a423506ee1903e89f1e08ec5f0ed430ff784ae9",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/6fbc9672905c7d5a885f2da2fc696f65840f4a66",
+                "reference": "6fbc9672905c7d5a885f2da2fc696f65840f4a66",
                 "shasum": ""
             },
             "require": {
@@ -1594,12 +1296,12 @@
             },
             "require-dev": {
                 "clue/stream-filter": "~1.2",
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "React\\Stream\\": "src"
+                    "React\\Stream\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1641,19 +1343,15 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/stream/issues",
-                "source": "https://github.com/reactphp/stream/tree/v1.2.0"
+                "source": "https://github.com/reactphp/stream/tree/v1.3.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2021-07-11T12:37:55+00:00"
+            "time": "2023-06-16T10:52:11+00:00"
         },
         {
             "name": "ringcentral/psr7",
@@ -1720,30 +1418,30 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1770,7 +1468,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1786,7 +1484,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1951,16 +1649,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -2001,9 +1699,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2436,16 +2134,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.7",
+            "version": "9.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
-                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
                 "shasum": ""
             },
             "require": {
@@ -2519,7 +2217,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
             },
             "funding": [
                 {
@@ -2535,7 +2233,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T08:58:40+00:00"
+            "time": "2023-07-10T04:04:23+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2837,16 +2535,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -2891,7 +2589,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -2899,7 +2597,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -3503,25 +3201,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3550,7 +3248,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -3566,7 +3264,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/dotenv",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4986815090297e25caca6b96b7c8e3e",
+    "content-hash": "1949a2c6506353cf770e0e88505cd11c",
     "packages": [
         {
             "name": "clue/http-proxy-react",
@@ -3394,7 +3394,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-json": "*",
         "ext-readline": "*"
     },

--- a/src/Zanzara/Context.php
+++ b/src/Zanzara/Context.php
@@ -478,6 +478,15 @@ class Context
     }
 
     /**
+     * Get message queue instance
+     * @return MessageQueue
+     */
+    public function getMessageQueue(): MessageQueue
+    {
+        return $this->container->get(MessageQueue::class);
+    }
+
+    /**
      * Get container instance
      * @return ContainerInterface
      */

--- a/src/Zanzara/Context.php
+++ b/src/Zanzara/Context.php
@@ -153,6 +153,43 @@ class Context
     }
 
     /**
+     * Sets an item of the chat data.
+     *
+     * Eg:
+     * $ctx->setChatDataItem('age', 21)->then(function($result) {
+     *
+     * });
+     *
+     * @param $key
+     * @param $data
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function setChatDataItem($key, $data, $ttl = false): PromiseInterface
+    {
+        $chatId = $this->update->getEffectiveChat()->getId();
+        return $this->cache->setChatDataItem($chatId, $key, $data, $ttl);
+    }
+
+    /**
+     * Sets multiple items of the chat data.
+     *
+     * Eg:
+     * $ctx->setChatDataItems(['name' => 'forsen', 'age' => 21])->then(function($result) {
+     *
+     * });
+     *
+     * @param $values array
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function setChatDataItems(array $values, $ttl = false): PromiseInterface
+    {
+        $chatId = $this->update->getEffectiveChat()->getId();
+        return $this->cache->setChatDataItems($chatId, $values, $ttl);
+    }
+
+    /**
      * Gets an item of the chat data.
      *
      * Eg:
@@ -170,22 +207,20 @@ class Context
     }
 
     /**
-     * Sets an item of the chat data.
+     * Gets multiple items of the chat data.
      *
      * Eg:
-     * $ctx->setChatData('age', 21)->then(function($result) {
+     * $ctx->getChatDataItems(['name', 'age'])->then(function($results) {
      *
      * });
      *
-     * @param $key
-     * @param $data
-     * @param $ttl
+     * @param $keys string[]
      * @return PromiseInterface
      */
-    public function setChatDataItem($key, $data, $ttl = false): PromiseInterface
+    public function getChatDataItems(array $keys): PromiseInterface
     {
         $chatId = $this->update->getEffectiveChat()->getId();
-        return $this->cache->setChatDataItem($chatId, $key, $data, $ttl);
+        return $this->cache->getChatDataItems($chatId, $keys);
     }
 
     /**
@@ -206,6 +241,60 @@ class Context
     }
 
     /**
+     * Deletes multiple items from the chat data.
+     *
+     * Eg:
+     * $ctx->deleteChatDataItems(['name', 'age'])->then(function($result) {
+     *
+     * });
+     *
+     * @param $keys string[]
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function deleteChatDataItems(array $keys): PromiseInterface
+    {
+        $chatId = $this->update->getEffectiveChat()->getId();
+        return $this->cache->deleteChatDataItems($chatId, $keys);
+    }
+
+    /**
+     * Sets an item of the user data.
+     *
+     * Eg:
+     * $ctx->setUserDataItem('age', 21)->then(function($result) {
+     *
+     * });
+     *
+     * @param $key
+     * @param $data
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function setUserDataItem($key, $data, $ttl = false): PromiseInterface
+    {
+        $userId = $this->update->getEffectiveUser()->getId();
+        return $this->cache->setUserDataItem($userId, $key, $data, $ttl);
+    }
+
+    /**
+     * Sets multiple items of the user data.
+     *
+     * Eg:
+     * $ctx->setUserDataItems(['name' => 'forsen', 'age' => 21])->then(function($result) {
+     *
+     * });
+     *
+     * @param $values array
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function setUserDataItems(array $values, $ttl = false): PromiseInterface
+    {
+        $userId = $this->update->getEffectiveUser()->getId();
+        return $this->cache->setUserDataItems($userId, $values, $ttl);
+    }
+
+    /**
      * Gets an item of the user data.
      *
      * Eg:
@@ -223,22 +312,20 @@ class Context
     }
 
     /**
-     * Sets an item of the user data.
+     * Gets multiple items of the user data.
      *
      * Eg:
-     * $ctx->setUserData('age', 21)->then(function($result) {
+     * $ctx->getUserDataItems(['name', 'age'])->then(function($results) {
      *
      * });
      *
-     * @param $key
-     * @param $data
-     * @param $ttl
+     * @param $keys string[]
      * @return PromiseInterface
      */
-    public function setUserDataItem($key, $data, $ttl = false): PromiseInterface
+    public function getUserDataItems(array $keys): PromiseInterface
     {
         $userId = $this->update->getEffectiveUser()->getId();
-        return $this->cache->setUserDataItem($userId, $key, $data, $ttl);
+        return $this->cache->getUserDataItems($userId, $keys);
     }
 
     /**
@@ -259,22 +346,57 @@ class Context
     }
 
     /**
+     * Deletes multiple items from the user data.
+     *
+     * Eg:
+     * $ctx->deleteUserDataItems(['name', 'age'])->then(function($result) {
+     *
+     * });
+     *
+     * @param $keys string[]
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function deleteUserDataItems(array $keys): PromiseInterface
+    {
+        $userId = $this->update->getEffectiveUser()->getId();
+        return $this->cache->deleteUserDataItems($userId, $keys);
+    }
+
+    /**
      * Sets an item of the global data.
      * This cache is not related to any chat or user.
      *
      * Eg:
-     * $ctx->setGlobalData('age', 21)->then(function($result) {
+     * $ctx->setGlobalDataItem('age', 21)->then(function($result) {
      *
      * });
      *
      * @param $key
      * @param $data
-     * @param $ttl
-     * @return PromiseInterface
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
     public function setGlobalDataItem($key, $data, $ttl = false): PromiseInterface
     {
         return $this->cache->setGlobalDataItem($key, $data, $ttl);
+    }
+
+    /**
+     * Sets multiple items of the global data.
+     * This cache is not related to any chat or user.
+     *
+     * Eg:
+     * $ctx->setGlobalDataItems(['name' => 'forsen', 'age' => 21])->then(function($result) {
+     *
+     * });
+     *
+     * @param $values array
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function setGlobalDataItems(array $values, $ttl = false): PromiseInterface
+    {
+        return $this->cache->setGlobalDataItems($values, $ttl);
     }
 
     /**
@@ -295,6 +417,23 @@ class Context
     }
 
     /**
+     * Gets multiple items of the global data.
+     * This cache is not related to any chat or user.
+     *
+     * Eg:
+     * $ctx->getGlobalDataItems(['name', 'age'])->then(function($results) {
+     *
+     * });
+     *
+     * @param $keys string[]
+     * @return PromiseInterface
+     */
+    public function getGlobalDataItems(array $keys): PromiseInterface
+    {
+        return $this->cache->getGlobalDataItems($keys);
+    }
+
+    /**
      * Deletes an item from the global data.
      * This cache is not related to any chat or user.
      *
@@ -309,6 +448,23 @@ class Context
     public function deleteGlobalDataItem($key): PromiseInterface
     {
         return $this->cache->deleteGlobalDataItem($key);
+    }
+
+    /**
+     * Deletes multiple items from the global data.
+     * This cache is not related to any chat or user.
+     *
+     * Eg:
+     * $ctx->deleteGlobalDataItems(['name', 'age'])->then(function($result) {
+     *
+     * });
+     *
+     * @param $keys string[]
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function deleteGlobalDataItems(array $keys): PromiseInterface
+    {
+        return $this->cache->deleteGlobalDataItems($keys);
     }
 
     /**

--- a/src/Zanzara/Context.php
+++ b/src/Zanzara/Context.php
@@ -165,9 +165,9 @@ class Context
      * @param $ttl float|false
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function setChatDataItem($key, $data, $ttl = false): PromiseInterface
+    public function setChatDataItem($key, $data, $ttl = false, $chatId = null): PromiseInterface
     {
-        $chatId = $this->update->getEffectiveChat()->getId();
+        $chatId = $chatId ?? $this->update->getEffectiveChat()->getId();
         return $this->cache->setChatDataItem($chatId, $key, $data, $ttl);
     }
 
@@ -183,16 +183,16 @@ class Context
      * @param $ttl float|false
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function setChatDataItems(array $values, $ttl = false): PromiseInterface
+    public function setChatDataItems(array $values, $ttl = false, $chatId = null): PromiseInterface
     {
-        $chatId = $this->update->getEffectiveChat()->getId();
+        $chatId = $chatId ?? $this->update->getEffectiveChat()->getId();
         return $this->cache->setChatDataItems($chatId, $values, $ttl);
     }
 
     /**
      * Gets an item of the chat data.
      *
-     * Eg:
+     * Eg:q
      * $ctx->getChatDataItem('age')->then(function($age) {
      *
      * });
@@ -200,9 +200,9 @@ class Context
      * @param $key
      * @return PromiseInterface
      */
-    public function getChatDataItem($key): PromiseInterface
+    public function getChatDataItem($key, $chatId = null): PromiseInterface
     {
-        $chatId = $this->update->getEffectiveChat()->getId();
+        $chatId = $chatId ?? $this->update->getEffectiveChat()->getId();
         return $this->cache->getChatDataItem($chatId, $key);
     }
 
@@ -217,9 +217,9 @@ class Context
      * @param $keys string[]
      * @return PromiseInterface
      */
-    public function getChatDataItems(array $keys): PromiseInterface
+    public function getChatDataItems(array $keys, $chatId = null): PromiseInterface
     {
-        $chatId = $this->update->getEffectiveChat()->getId();
+        $chatId = $chatId ?? $this->update->getEffectiveChat()->getId();
         return $this->cache->getChatDataItems($chatId, $keys);
     }
 
@@ -234,9 +234,9 @@ class Context
      * @param $key
      * @return PromiseInterface
      */
-    public function deleteChatDataItem($key): PromiseInterface
+    public function deleteChatDataItem($key, $chatId = null): PromiseInterface
     {
-        $chatId = $this->update->getEffectiveChat()->getId();
+        $chatId = $chatId ?? $this->update->getEffectiveChat()->getId();
         return $this->cache->deleteChatDataItem($chatId, $key);
     }
 
@@ -251,9 +251,9 @@ class Context
      * @param $keys string[]
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function deleteChatDataItems(array $keys): PromiseInterface
+    public function deleteChatDataItems(array $keys, $chatId = null): PromiseInterface
     {
-        $chatId = $this->update->getEffectiveChat()->getId();
+        $chatId = $chatId ?? $this->update->getEffectiveChat()->getId();
         return $this->cache->deleteChatDataItems($chatId, $keys);
     }
 
@@ -270,9 +270,9 @@ class Context
      * @param $ttl float|false
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function setUserDataItem($key, $data, $ttl = false): PromiseInterface
+    public function setUserDataItem($key, $data, $ttl = false, $userId = null): PromiseInterface
     {
-        $userId = $this->update->getEffectiveUser()->getId();
+        $userId = $userId ?? $this->update->getEffectiveUser()->getId();
         return $this->cache->setUserDataItem($userId, $key, $data, $ttl);
     }
 
@@ -288,9 +288,9 @@ class Context
      * @param $ttl float|false
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function setUserDataItems(array $values, $ttl = false): PromiseInterface
+    public function setUserDataItems(array $values, $ttl = false, $userId = null): PromiseInterface
     {
-        $userId = $this->update->getEffectiveUser()->getId();
+        $userId = $userId ?? $this->update->getEffectiveUser()->getId();
         return $this->cache->setUserDataItems($userId, $values, $ttl);
     }
 
@@ -305,9 +305,9 @@ class Context
      * @param $key
      * @return PromiseInterface
      */
-    public function getUserDataItem($key): PromiseInterface
+    public function getUserDataItem($key, $userId = null): PromiseInterface
     {
-        $userId = $this->update->getEffectiveUser()->getId();
+        $userId = $userId ?? $this->update->getEffectiveUser()->getId();
         return $this->cache->getUserDataItem($userId, $key);
     }
 
@@ -322,9 +322,9 @@ class Context
      * @param $keys string[]
      * @return PromiseInterface
      */
-    public function getUserDataItems(array $keys): PromiseInterface
+    public function getUserDataItems(array $keys, $userId = null): PromiseInterface
     {
-        $userId = $this->update->getEffectiveUser()->getId();
+        $userId = $userId ?? $this->update->getEffectiveUser()->getId();
         return $this->cache->getUserDataItems($userId, $keys);
     }
 
@@ -339,9 +339,9 @@ class Context
      * @param $key
      * @return PromiseInterface
      */
-    public function deleteUserDataItem($key): PromiseInterface
+    public function deleteUserDataItem($key, $userId = null): PromiseInterface
     {
-        $userId = $this->update->getEffectiveUser()->getId();
+        $userId = $userId ?? $this->update->getEffectiveUser()->getId();
         return $this->cache->deleteUserDataItem($userId, $key);
     }
 
@@ -356,9 +356,9 @@ class Context
      * @param $keys string[]
      * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
-    public function deleteUserDataItems(array $keys): PromiseInterface
+    public function deleteUserDataItems(array $keys, $userId = null): PromiseInterface
     {
-        $userId = $this->update->getEffectiveUser()->getId();
+        $userId = $userId ?? $this->update->getEffectiveUser()->getId();
         return $this->cache->deleteUserDataItems($userId, $keys);
     }
 

--- a/src/Zanzara/Listener/ListenerCollector.php
+++ b/src/Zanzara/Listener/ListenerCollector.php
@@ -235,11 +235,17 @@ abstract class ListenerCollector
      * @throws DependencyException
      * @throws NotFoundException
      */
-    public function onCbQueryData(array $data, $callback, array $filters = []): MiddlewareCollector
+    public function onCbQueryData(string|array $data, $callback, array $filters = []): MiddlewareCollector
     {
-        // merge values with "|" (eg. "accept|refuse|later"), then ListenerResolver will check the callback data
-        // against that regex.
-        $id = '/' . implode('|', $data) . '/';
+        // if it's an array:
+        // we merge options with "|" (eg. "accept|refuse|later"),
+        // then ListenerResolver will check the callback data against that regex.
+        // if not we'll make it parameterised (ex. "accept {user_id}")
+
+        $id = is_array($data) ?
+            '/' . implode('|', $data) . '/' :
+            '/^' . preg_replace(self::PARAMETER_REGEX, '(?<$1>.*)', $data) . ' ?$/miu';
+
         $listener = new Listener($callback, $this->container, $id, $filters);
         $this->listeners['cb_query_data'][$id] = $listener;
         return $listener;

--- a/src/Zanzara/MessageQueue.php
+++ b/src/Zanzara/MessageQueue.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Zanzara;
 
+use DI\DependencyException;
+use DI\NotFoundException;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\TimerInterface;
+use Zanzara\Support\CallableResolver;
 use Zanzara\Telegram\Telegram;
 use Zanzara\Telegram\Type\Response\TelegramException;
 
@@ -14,6 +17,7 @@ use Zanzara\Telegram\Type\Response\TelegramException;
  */
 class MessageQueue
 {
+    use CallableResolver;
 
     /**
      * @var LoopInterface
@@ -36,6 +40,16 @@ class MessageQueue
     private $config;
 
     /**
+     * @var array
+     */
+    private $queueList;
+
+    /**
+     * @var TimerInterface
+     */
+    private $dequeueTimer;
+
+    /**
      * MessageQueue constructor.
      * @param Telegram $telegram
      * @param ZanzaraLogger $logger
@@ -48,37 +62,155 @@ class MessageQueue
         $this->logger = $logger;
         $this->loop = $loop;
         $this->config = $config;
+        $this->queueList = [];
     }
 
     /**
-     * @param array $chatIds
-     * @param string $text
-     * @param array $opt
+     * Create new queue list, returns queue id
+     *
+     * caution: be sure $chatIds elements are not null or false as it would mean
+     * in skipping all remaining requests and completion of that queue
+     *
+     * @param string $method
+     * @param int[] $chatIds
+     * @param array|null $opt
+     * @param callable|null $callback
+     * @return int
+     * @throws DependencyException
+     * @throws NotFoundException
      */
-    public function push(array $chatIds, string $text, array $opt = [])
+    public function new(string $method, array $chatIds, ?array $opt = [], ?callable $callback = null): int
     {
-        $payload = []; // indexed array of Telegram params
-        $opt['text'] = $text;
-        // prepare the params array for each chatId
-        foreach ($chatIds as $chatId) {
-            $clone = $opt;
-            $clone['chat_id'] = $chatId;
-            array_push($payload, $clone);
-        }
-        $dequeue = function (TimerInterface $timer) use (&$payload) {
-            // if there's no more message to dequeue cancel the timer
-            if (!$payload) {
-                $this->loop->cancelTimer($timer);
-                return;
-            }
+        $id = $this->generateQueueID();
+        $this->queueList[$id] = [
+            'method' => $method,
+            'params' => $opt,
+            'pending' => array_reverse($chatIds),
+            'results' => [],
+            'callback' => isset($callback) ? $this->getCallable($callback) : null,
+        ];
 
-            // pop and process
-            $params = array_pop($payload);
-            $this->telegram->doSendMessage($params)->/** @scrutinizer ignore-call */ otherwise(function (TelegramException $error) {
-                $this->logger->error("Failed to send message in bulk mode, reason: $error");
-            });
-        };
-        $this->loop->addPeriodicTimer($this->config->getBulkMessageInterval(), $dequeue);
+        $this->start();
+
+        return $id;
     }
 
+    /**
+     * Push new chat_ids into existing queue list
+     * Returns false if no queue with that id found
+     *
+     * caution: be sure $chatIds elements are not null or false as it would mean
+     * in skipping all remaining requests and completion of that queue
+     * @param int[] $chatIds
+     */
+    public function push(int $queueId, array $chatIds): bool|int
+    {
+        if (isset($this->queueList[$queueId])) {
+            return array_push($this->queueList[$queueId]['pending'], $chatIds);
+        }
+
+        return false;
+    }
+
+    /**
+     * Start queue processing if it's not already, or force it to
+     *
+     * @param bool $force
+     * @return void
+     */
+    public function start(bool $force = false)
+    {
+        if ($force || is_null($this->dequeueTimer)) {
+            $this->dequeueTimer = $this->loop->addPeriodicTimer($this->config->getBulkMessageInterval(), [$this, 'process']);
+        }
+    }
+
+    public function process(): void
+    {
+        $id = array_key_first($this->queueList);
+        if ($id) {
+            $chatId = array_pop($this->queueList[$id]['pending']);
+            if ($chatId) {
+                $this->telegram->callApi(
+                    $this->queueList[$id]['method'],
+                    $this->queueList[$id]['params'] + ['chat_id' => $chatId]
+                )->catch(function (TelegramException $error) {
+                    $this->logger->error("Failed to send message in bulk mode, reason: $error");
+                });
+                echo 'Creating request call with method ',
+                $this->queueList[$id]['method'],
+                ' and chat_id of ',
+                $chatId,
+                PHP_EOL;
+
+                if (isset($this->queueList[$id]['pending'][0])) {
+                    return; // there are more to process
+                }
+            }
+
+            $this->cancel($id, true); // Completed queue list
+
+        } else {
+            $this->stop();
+        }
+    }
+
+    /**
+     * Stop queue processing periodic timer
+     *
+     * @param bool $purge
+     * @return void
+     */
+    public function stop(bool $purge = false): void
+    {
+        if ($purge) {
+            $this->queueList = [];
+        }
+
+        $this->loop->cancelTimer($this->dequeueTimer);
+        $this->dequeueTimer = null;
+    }
+
+
+    /**
+     * Cancel/removes a queue from queue list
+     * Returns false if no queue with that id found
+     *
+     * @param int $queueId
+     * @param bool $fireCallback
+     * @return bool
+     */
+    public function cancel(int $queueId, bool $fireCallback = false): bool
+    {
+        if (isset($this->queueList[$queueId])) {
+            if ($fireCallback && isset($this->queueList[$queueId]['callback'])) {
+                $this->loop->futureTick(
+                    $this->wrapCallback($this->queueList[$queueId]['callback'])
+                );
+            }
+
+            unset($this->queueList[$queueId]);
+            return true;
+        }
+
+        return false;
+    }
+
+    private function generateQueueID(): int
+    {
+        do {
+            $id = rand(11111, 99999);
+            if (!isset($this->queueList[$id])) {
+                return $id;
+            }
+
+        } while (true);
+    }
+
+    private function wrapCallback($callback): \Closure
+    {
+        return function () use ($callback) {
+            call_user_func($callback);
+        };
+    }
 }

--- a/src/Zanzara/Zanzara.php
+++ b/src/Zanzara/Zanzara.php
@@ -240,6 +240,16 @@ class Zanzara extends ListenerResolver
     }
 
     /**
+     * Get message queue instance
+     *
+     * @return MessageQueue
+     */
+    public function getMessageQueue(): MessageQueue
+    {
+        return $this->container->get(MessageQueue::class);
+    }
+
+    /**
      * @param $exception
      * @param Context $ctx
      * @return bool

--- a/src/Zanzara/Zanzara.php
+++ b/src/Zanzara/Zanzara.php
@@ -24,7 +24,6 @@ use Zanzara\UpdateMode\ReactPHPWebhook;
  */
 class Zanzara extends ListenerResolver
 {
-
     /**
      * @var Config
      */
@@ -130,18 +129,36 @@ class Zanzara extends ListenerResolver
      * This cache is not related to any chat or user.
      *
      * Eg:
-     * $ctx->setGlobalData('age', 21)->then(function($result) {
+     * $ctx->setGlobalDataItem('age', 21)->then(function($result) {
      *
      * });
      *
      * @param $key
      * @param $data
-     * @param $ttl
-     * @return PromiseInterface
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
      */
     public function setGlobalDataItem($key, $data, $ttl = false): PromiseInterface
     {
         return $this->cache->setGlobalDataItem($key, $data, $ttl);
+    }
+
+    /**
+     * Sets multiple items of the global data.
+     * This cache is not related to any chat or user.
+     *
+     * Eg:
+     * $ctx->setGlobalDataItems(['name' => 'forsen', 'age' => 21])->then(function($result) {
+     *
+     * });
+     *
+     * @param $values array
+     * @param $ttl float|false
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function setGlobalDataItems(array $values, $ttl = false): PromiseInterface
+    {
+        return $this->cache->setGlobalDataItems($values, $ttl);
     }
 
     /**
@@ -162,6 +179,23 @@ class Zanzara extends ListenerResolver
     }
 
     /**
+     * Gets multiple items of the global data.
+     * This cache is not related to any chat or user.
+     *
+     * Eg:
+     * $ctx->getGlobalDataItems(['name', 'age'])->then(function($results) {
+     *
+     * });
+     *
+     * @param $keys string[]
+     * @return PromiseInterface
+     */
+    public function getGlobalDataItems(array $keys): PromiseInterface
+    {
+        return $this->cache->getGlobalDataItems($keys);
+    }
+
+    /**
      * Deletes an item from the global data.
      * This cache is not related to any chat or user.
      *
@@ -179,6 +213,23 @@ class Zanzara extends ListenerResolver
     }
 
     /**
+     * Deletes multiple items from the global data.
+     * This cache is not related to any chat or user.
+     *
+     * Eg:
+     * $ctx->deleteGlobalDataItems(['name', 'age'])->then(function($result) {
+     *
+     * });
+     *
+     * @param $keys string[]
+     * @return PromiseInterface<bool> Returns a promise which resolves to `true` on success or `false` on error
+     */
+    public function deleteGlobalDataItems(array $keys): PromiseInterface
+    {
+        return $this->cache->deleteGlobalDataItems($keys);
+    }
+
+    /**
      * Wipe entire cache.
      *
      * @return PromiseInterface
@@ -191,7 +242,7 @@ class Zanzara extends ListenerResolver
     /**
      * @param $exception
      * @param Context $ctx
-     * @return bool|void
+     * @return bool
      */
     public function callOnException(Context $ctx, $exception)
     {
@@ -203,5 +254,4 @@ class Zanzara extends ListenerResolver
 
         return true;
     }
-
 }

--- a/tests/Conversation/ConversationTest.php
+++ b/tests/Conversation/ConversationTest.php
@@ -37,6 +37,21 @@ class ConversationTest extends TestCase
         });
 
         $bot->onUpdate(function (Context $ctx) {
+            $ctx->setChatDataItems(['first_test' => 'first_value', 'second_test' => 'second_value'])->then(function () use ($ctx) {
+                $ctx->getChatDataItems(['first_test', 'second_test'])->then(function ($res) use ($ctx) {
+                    $this->assertEquals('first_value', $res['first_test']);
+                    $this->assertEquals('second_value', $res['second_test']);
+                    $ctx->deleteChatDataItems(['first_test', 'second_test'])->then(function () use ($ctx) {
+                        $ctx->getChatDataItems(['first_test', 'second_test'])->then(function ($res) use ($ctx) {
+                            $this->assertNull($res['first_test']);
+                            $this->assertNull($res['second_test']);
+                        });
+                    });
+                });
+            });
+        });
+
+        $bot->onUpdate(function (Context $ctx) {
             $ctx->setUserDataItem('key_test', 'value_test')->then(function () use ($ctx) {
                 $ctx->getUserDataItem('key_test')->then(function ($res) use ($ctx) {
                     $this->assertEquals('value_test', $res);
@@ -49,12 +64,40 @@ class ConversationTest extends TestCase
             });
         });
 
+        $bot->onUpdate(function (Context $ctx) {
+            $ctx->setUserDataItems(['first_test' => 'first_value', 'second_test' => 'second_value'])->then(function () use ($ctx) {
+                $ctx->getUserDataItems(['first_test', 'second_test'])->then(function ($res) use ($ctx) {
+                    $this->assertEquals('first_value', $res['first_test']);
+                    $this->assertEquals('second_value', $res['second_test']);
+                    $ctx->deleteUserDataItems(['first_test', 'second_test'])->then(function () use ($ctx) {
+                        $ctx->getUserDataItems(['first_test', 'second_test'])->then(function ($res) use ($ctx) {
+                            $this->assertNull($res['first_test']);
+                            $this->assertNull($res['second_test']);
+                        });
+                    });
+                });
+            });
+        });
+
         $bot->setGlobalDataItem('key_test', 'value_test')->then(function () use ($bot) {
             $bot->getGlobalDataItem('key_test')->then(function ($res) use ($bot) {
                 $this->assertEquals('value_test', $res);
                 $bot->deleteGlobalDataItem('key_test')->then(function () use ($bot) {
                     $bot->getGlobalDataItem('key_test')->then(function ($res) use ($bot) {
                         $this->assertNull($res);
+                    });
+                });
+            });
+        });
+
+        $bot->setGlobalDataItems(['first_test' => 'first_value', 'second_test' => 'second_value'])->then(function () use ($bot) {
+            $bot->getGlobalDataItems(['first_test', 'second_test'])->then(function ($res) use ($bot) {
+                $this->assertEquals('first_value', $res['first_test']);
+                $this->assertEquals('second_value', $res['second_test']);
+                $bot->deleteGlobalDataItems(['first_test', 'second_test'])->then(function () use ($bot) {
+                    $bot->getGlobalDataItems(['first_test', 'second_test'])->then(function ($res) use ($bot) {
+                        $this->assertNull($res['first_test']);
+                        $this->assertNull($res['second_test']);
                     });
                 });
             });

--- a/tests/Listener/RegexTest.php
+++ b/tests/Listener/RegexTest.php
@@ -139,7 +139,7 @@ class RegexTest extends TestCase
         $bot->run();
     }
 
-    public function testCallbackQuery()
+    public function testCallbackQueryText()
     {
         $config = new Config();
         $config->setUpdateMode(Config::WEBHOOK_MODE);
@@ -173,6 +173,45 @@ class RegexTest extends TestCase
             $this->assertSame('remove', $inlineKeyboard[1][0]->getCallbackData());
             $this->assertSame('Read', $inlineKeyboard[1][1]->getText());
             $this->assertSame('read', $inlineKeyboard[1][1]->getCallbackData());
+        });
+
+        $bot->run();
+    }
+    public function testCallbackQueryData()
+    {
+        $config = new Config();
+        $config->setUpdateMode(Config::WEBHOOK_MODE);
+        $config->setSafeMode(true);
+        $config->setUpdateStream(__DIR__ . '/../update_types/callback_query_parameters.json');
+        $bot = new Zanzara('test', $config);
+
+        $bot->onCbQueryData('modify {id}', function (Context $ctx, $id) {
+            $this->assertSame('12345', $id);
+            $callbackQuery = $ctx->getCallbackQuery();
+            $message = $callbackQuery->getMessage();
+            $this->assertSame('666728699048485871', $callbackQuery->getId());
+            $this->assertSame(222222222, $callbackQuery->getFrom()->getId());
+            $this->assertSame(false, $callbackQuery->getFrom()->isBot());
+            $this->assertSame('Michael', $callbackQuery->getFrom()->getFirstName());
+            $this->assertSame('mscott', $callbackQuery->getFrom()->getUsername());
+            $this->assertSame('it', $callbackQuery->getFrom()->getLanguageCode());
+            $this->assertSame(23759, $message->getMessageId());
+            $this->assertSame(222222222, $message->getChat()->getId());
+            $this->assertSame('Michael', $message->getChat()->getFirstName());
+            $this->assertSame('mscott', $message->getChat()->getUsername());
+            $this->assertSame('private', $message->getChat()->getType());
+            $this->assertSame(1584984731, $message->getDate());
+            $this->assertSame('Manage your data', $message->getText());
+            $this->assertSame('modify 12345', $callbackQuery->getData());
+            $inlineKeyboard = $message->getReplyMarkup()->getInlineKeyboard();
+            $this->assertSame('Add', $inlineKeyboard[0][0]->getText());
+            $this->assertSame('add 12345', $inlineKeyboard[0][0]->getCallbackData());
+            $this->assertSame('Modify', $inlineKeyboard[0][1]->getText());
+            $this->assertSame('modify 12345', $inlineKeyboard[0][1]->getCallbackData());
+            $this->assertSame('Remove', $inlineKeyboard[1][0]->getText());
+            $this->assertSame('remove 12345', $inlineKeyboard[1][0]->getCallbackData());
+            $this->assertSame('Read', $inlineKeyboard[1][1]->getText());
+            $this->assertSame('read 12345', $inlineKeyboard[1][1]->getCallbackData());
         });
 
         $bot->run();

--- a/tests/update_types/callback_query_parameters.json
+++ b/tests/update_types/callback_query_parameters.json
@@ -1,0 +1,56 @@
+{
+    "update_id": 52259546,
+    "callback_query": {
+        "id": "666728699048485871",
+        "from": {
+            "id": 222222222,
+            "is_bot": false,
+            "first_name": "Michael",
+            "username": "mscott",
+            "language_code": "it"
+        },
+        "message": {
+            "message_id": 23759,
+            "from": {
+                "id": 333333333,
+                "is_bot": true,
+                "first_name": "ScottBot",
+                "username": "ScottBot"
+            },
+            "chat": {
+                "id": 222222222,
+                "first_name": "Michael",
+                "username": "mscott",
+                "type": "private"
+            },
+            "date": 1584984731,
+            "text": "Manage your data",
+            "reply_markup": {
+                "inline_keyboard": [
+                    [
+                        {
+                            "text": "Add",
+                            "callback_data": "add 12345"
+                        },
+                        {
+                            "text": "Modify",
+                            "callback_data": "modify 12345"
+                        }
+                    ],
+                    [
+                        {
+                            "text": "Remove",
+                            "callback_data": "remove 12345"
+                        },
+                        {
+                            "text": "Read",
+                            "callback_data": "read 12345"
+                        }
+                    ]
+                ]
+            }
+        },
+        "chat_instance": "4628664761794766620",
+        "data": "modify 12345"
+    }
+}

--- a/tests/zen-circus/cache_test.php
+++ b/tests/zen-circus/cache_test.php
@@ -17,19 +17,19 @@ $config->setUpdateMode(Config::POLLING_MODE);
 $bot = new Zanzara($_ENV['BOT_TOKEN'], $config);
 
 /**
- *  There are 3 separed cache environment:
+ *  There are 3 separated cache environment:
  *
  *  - chatdata --> indexed by chatid
  *  - userdata --> indexed by userid
  *  - globaldata --> global data, shared by every user/chat
  *
- *  Example for chatdata but it's applicable for each of them:
+ *  Example for chatdata, but it's applicable for each of them:
  *
  *  $ctx->setChatData("key1", "value1")
  *  $ctx->setChatData("key2", "value2")
  *  With these methods I'm writing inside the cache data of the chatId of the context.
  *  You can get that that data with $ctx->getChatData(). This method will return in a promise
- *  the assoc array of the data previusly saved. In this case ["key1" => "value1", "key2" => "value2"].
+ *  the assoc array of the data previously saved. In this case ["key1" => "value1", "key2" => "value2"].
  *  The key must be a string but the value can be a generic object (another assoc array for example).
  *  If you want to access only one item of the chat you must use $ctx->getItemChatData("key2"). This method in a promise
  *  will return only the value associated with key2.
@@ -38,7 +38,7 @@ $bot = new Zanzara($_ENV['BOT_TOKEN'], $config);
  *
  *  For userdata it's the same, but it's indexed on the userId of the context.
  *
- *  The only differenct with global data is that it can be accessed with the $ctx(only for simplicity but it's
+ *  The only different with global data is that it can be accessed with the $ctx(only for simplicity but it's
  *  not referred to the context) and with the $bot instance.
  *
  *


### PR DESCRIPTION
There are descriptions in commit messages, fixes #61.

If you think there is a better approach to these, please feel free to modify: 

#### array_is_list in ZanzaraCache.php:79 (changes php version requirement) :
```php
private function resolveKeys($dataType, $id, $keys): array
{
    if (array_is_list($keys)) {
        return array_map(fn($key) => $this->resolveKey($dataType, $id, $key), $keys);
    }

    return array_combine(
        array_map(fn($key) => $this->resolveKey($dataType, $id, $key), array_keys($keys)),
        array_values($keys)
    );
}
```

#### using explode in ZanzaraCache.php:91 :
```php
public function resolveGetItems($result)
{
    return resolve(array_combine(
        array_map(
            function ($key) {
                $ex = explode('@', $key, 3);
                // there is no @$id in global data
                if ($ex[0] === 'GLOBAL_DATA') {
                    return $ex[1];
                }

                return $ex[2];
            },
            array_keys($result)),
        array_values($result)
    ));
}
```
