### PR TITLE
Bump `opis/closure` and PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "test": "vendor/bin/phpunit"
     },
     "require": {
-        "php": ">=7.4",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-readline": "*",
         "react/event-loop": "^1.3",
@@ -34,7 +34,7 @@
         "php-http/multipart-stream-builder": "^1.2",
         "netresearch/jsonmapper": "^4.1",
         "clue/http-proxy-react": "^1.8",
-        "opis/closure": "^3.6"
+        "opis/closure": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87eeace13e7024a0b152bd271896d99e",
+    "content-hash": "56b0109bce57bcd7f5a66aba4ea2bff3",
     "packages": [
         {
             "name": "clue/http-proxy-react",
@@ -289,34 +289,33 @@
         },
         {
             "name": "opis/closure",
-            "version": "3.6.3",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opis/closure.git",
-                "reference": "3d81e4309d2a927abbe66df935f4bb60082805ad"
+                "reference": "9b6ef5f622b4b29cf98bdc144f2a370c3a40d4df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opis/closure/zipball/3d81e4309d2a927abbe66df935f4bb60082805ad",
-                "reference": "3d81e4309d2a927abbe66df935f4bb60082805ad",
+                "url": "https://api.github.com/repos/opis/closure/zipball/9b6ef5f622b4b29cf98bdc144f2a370c3a40d4df",
+                "reference": "9b6ef5f622b4b29cf98bdc144f2a370c3a40d4df",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0 || ^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "jeremeamia/superclosure": "^2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.6.x-dev"
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {
                 "files": [
-                    "functions.php"
+                    "src/functions.php"
                 ],
                 "psr-4": {
                     "Opis\\Closure\\": "src/"
@@ -336,7 +335,7 @@
                     "email": "sarca_sorin@hotmail.com"
                 }
             ],
-            "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary objects.",
+            "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary data.",
             "homepage": "https://opis.io/closure",
             "keywords": [
                 "anonymous functions",
@@ -348,9 +347,9 @@
             ],
             "support": {
                 "issues": "https://github.com/opis/closure/issues",
-                "source": "https://github.com/opis/closure/tree/3.6.3"
+                "source": "https://github.com/opis/closure/tree/4.3.1"
             },
-            "time": "2022-01-27T09:35:39+00:00"
+            "time": "2025-01-10T20:42:24+00:00"
         },
         {
             "name": "php-di/invoker",
@@ -3692,14 +3691,14 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-readline": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Several features of `opis/closure` use features deprecated in PHP 8.4:

```
PHP Deprecated:  Opis\Closure\unserialize(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead in /Users/kix/Documents/Code/eversource/vendor/opis/closure/functions.php on line 32
```

Bumping the lib version resolves the issue. PHP version was also bumped since lates version, `7.4`, reached EOL in 2022.